### PR TITLE
docs: Update Opera installation guide according to upstream

### DIFF
--- a/Applications/Web-Browsers/Opera/Opera.md
+++ b/Applications/Web-Browsers/Opera/Opera.md
@@ -5,8 +5,8 @@ Opera is a web browser developed by Opera Software. The latest version is availa
 To install Opera on AnduinOS, you can run the following commands:
 
 ```bash
-sudo sh -c 'echo "deb http://deb.opera.com/opera-stable/ stable non-free" >> /etc/apt/sources.list.d/opera.list'
-wget -qO - https://deb.opera.com/archive.key | sudo apt-key add -
+wget -qO- https://deb.opera.com/archive.key | gpg --dearmor | sudo dd of=/usr/share/keyrings/opera-browser.gpg
+echo "deb [signed-by=/usr/share/keyrings/opera-browser.gpg] https://deb.opera.com/opera-stable/ stable non-free" | sudo dd of=/etc/apt/sources.list.d/opera-archive.list
 sudo apt update
 sudo apt install opera-stable -y
 ```


### PR DESCRIPTION
Do not use `apt-key add` anymore.

upstream: https://deb.opera.com/manual.html