### PR TITLE
docs: Replace "dpkg -i" with "apt install"

### DIFF
--- a/Applications/Code-Editors/Obsidian/Obsidian.md
+++ b/Applications/Code-Editors/Obsidian/Obsidian.md
@@ -7,8 +7,7 @@ To install Obsidian on AnduinOS, follow these steps:
 ```bash title="Install Obsidian"
 link=https://github.com/obsidianmd/obsidian-releases/releases/download/v1.7.7/obsidian_1.7.7_amd64.deb
 wget $link -O /tmp/obsidian.deb
-sudo dpkg -i /tmp/obsidian.deb
-sudo apt install --fix-broken -y
+sudo apt install /tmp/obsidian.deb -y
 rm /tmp/obsidian.deb
 ```
 

--- a/Applications/Communication/Discord/Discord.md
+++ b/Applications/Communication/Discord/Discord.md
@@ -7,8 +7,7 @@ To install Discord on AnduinOS, you can run:
 ```bash
 link="https://discord.com/api/download?platform=linux&format=deb"
 wget -O discord.deb $link
-sudo dpkg -i discord.deb
-sudo apt install --fix-broken -y
+sudo apt install ./discord.deb -y
 rm discord.deb
 ```
 

--- a/Applications/Communication/Feishu/Feishu.md
+++ b/Applications/Communication/Feishu/Feishu.md
@@ -2,7 +2,7 @@
 
 ByteDance Feishu is a communication and collaboration tool. It is a competitor to Slack and Microsoft Teams.
 
-To Install Feishu on AnduinOS, first download a deb package form [here](https://www.feishu.cn/download). Then you can install it with `dpkg`:
+To Install Feishu on AnduinOS, first download a deb package form [here](https://www.feishu.cn/download). Then you can install it with `apt`:
 
 <!-- The link needs to be updated regularly. -->
 
@@ -10,8 +10,7 @@ To Install Feishu on AnduinOS, first download a deb package form [here](https://
 api=https://www.feishu.cn/api/package_info?platform=10
 download_link=$(curl -s $api | jq -r '.data.download_link')
 wget $download_link -O Feishu.deb
-sudo dpkg -i Feishu.deb
-sudo apt install --fix-broken -y
+sudo apt install ./Feishu.deb -y
 rm Feishu.deb
 ```
 

--- a/Applications/Communication/QQ/QQ.md
+++ b/Applications/Communication/QQ/QQ.md
@@ -2,14 +2,13 @@
 
 Tencent QQ (Chinese: 腾讯QQ), also known as QQ, is an instant messaging software service and web portal developed by the Chinese technology company Tencent. QQ offers services that provide online social games, music, shopping, microblogging, movies, and group and voice chat software.
 
-To Install QQ on AnduinOS, first download a deb package form [here](https://im.qq.com/linuxqq/index.shtml). Then you can install it with `dpkg`:
+To Install QQ on AnduinOS, first download a deb package form [here](https://im.qq.com/linuxqq/index.shtml). Then you can install it with `apt`:
 
 <!-- The link needs to be updated regularly. -->
 
 ```bash
 wget https://dldir1.qq.com/qqfile/qq/QQNT/Linux/QQ_3.2.15_241224_amd64_01.deb -O qq.deb
-sudo dpkg -i qq.deb
-sudo apt install --fix-broken -y
+sudo apt install ./qq.deb -y
 rm qq.deb
 ```
 

--- a/Applications/Communication/Slack/Slack.md
+++ b/Applications/Communication/Slack/Slack.md
@@ -7,8 +7,7 @@ To install Slack on AnduinOS, you can run the following commands in the terminal
 ```bash
 link="https://downloads.slack-edge.com/desktop-releases/linux/x64/4.39.95/slack-desktop-4.39.95-amd64.deb"
 wget $link -O slack.deb
-sudo dpkg -i slack.deb
-sudo apt install --fix-broken -y
+sudo apt install ./slack.deb -y
 rm slack.deb
 ```
 

--- a/Applications/Communication/WeChat/WeChat.md
+++ b/Applications/Communication/WeChat/WeChat.md
@@ -6,8 +6,7 @@ To Install WeChat on AnduinOS, you can run:
 
 ```bash
 wget https://dldir1v6.qq.com/weixin/Universal/Linux/WeChatLinux_x86_64.deb -O wechat.deb
-sudo dpkg -i wechat.deb
-sudo apt install --fix-broken -y
+sudo apt install ./wechat.deb -y
 rm wechat.deb
 ```
 

--- a/Applications/Communication/Zoom/Zoom.md
+++ b/Applications/Communication/Zoom/Zoom.md
@@ -6,8 +6,7 @@ To install Zoom on AnduinOS, you can run the following commands in the terminal:
 
 ```bash
 wget https://zoom.us/client/latest/zoom_amd64.deb -O zoom.deb
-sudo dpkg -i zoom.deb
-sudo apt install --fix-broken -y
+sudo apt install ./zoom.deb -y
 rm zoom.deb
 ```
 

--- a/Applications/Database-Tools/Azure-Data-Studio/Azure-Data-Studio.md
+++ b/Applications/Database-Tools/Azure-Data-Studio/Azure-Data-Studio.md
@@ -7,8 +7,7 @@ To install Azure Data Studio on AnduinOS, run the following commands.
 ```bash
 url=https://go.microsoft.com/fwlink/?linkid=2275602
 curl -fsSL $url -o azure-data-studio.deb
-sudo dpkg -i azure-data-studio.deb
-sudo apt install --fix-broken -y
+sudo apt install ./azure-data-studio.deb -y
 rm azure-data-studio.deb
 ```
 

--- a/Applications/Development/CUDA/CUDA.md
+++ b/Applications/Development/CUDA/CUDA.md
@@ -52,7 +52,7 @@ Run:
 
 ```bash
 echo "Installing CUDNN..."
-sudo dpkg -i ./cudnn-local-repo-ubuntu2204-8.9.0.131_1.0-1_amd64_cuda11.deb
+sudo apt-get install ./cudnn-local-repo-ubuntu2204-8.9.0.131_1.0-1_amd64_cuda11.deb -y
 sudo cp /var/cudnn-local-repo-*/cudnn-local-*-keyring.gpg /usr/share/keyrings/
 sudo apt-get update
 sudo apt-get install libcudnn8=8.9.0.131-1+cuda11.8

--- a/Applications/Development/Docker/Docker.md
+++ b/Applications/Development/Docker/Docker.md
@@ -220,8 +220,7 @@ If you insist on using Docker Desktop, you can run:
 ```bash
 cd ~
 wget https://desktop.docker.com/linux/main/amd64/docker-desktop-amd64.deb -O docker-desktop-amd64.deb
-sudo dpkg -i docker-desktop-amd64.deb
-sudo apt install --fix-broken -y
+sudo apt install ./docker-desktop-amd64.deb -y
 rm docker-desktop-amd64.deb
 ```
 

--- a/Applications/Development/PowerShell/PowerShell.md
+++ b/Applications/Development/PowerShell/PowerShell.md
@@ -7,7 +7,7 @@ To install PowerShell on AnduinOS, you can run:
 ```bash
 cd ~
 wget -q "https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb" -O packages-microsoft-prod.deb
-sudo dpkg -i ./packages-microsoft-prod.deb
+sudo apt install ./packages-microsoft-prod.deb
 rm ./packages-microsoft-prod.deb
 sudo apt update
 sudo apt install powershell

--- a/Applications/Download-Tools/Motrix/Motrix.md
+++ b/Applications/Download-Tools/Motrix/Motrix.md
@@ -8,8 +8,7 @@ To install Motrix on AnduinOS, you can run:
 
 ```bash
 wget https://dl.motrix.app/release/Motrix_1.8.19_amd64.deb -O Motrix.deb
-sudo dpkg -i ./Motrix.deb
-sudo apt install --fix-broken -y
+sudo apt install ./Motrix.deb -y
 rm Motrix.deb
 ```
 

--- a/Applications/Games/Minecraft/Minecraft.md
+++ b/Applications/Games/Minecraft/Minecraft.md
@@ -6,8 +6,7 @@ To install Minecraft on AnduinOS, you can run:
 
 ```bash
 wget https://launcher.mojang.com/download/Minecraft.deb -O /tmp/minecraft.deb
-sudo dpkg -i /tmp/minecraft.deb
-sudo apt install --fix-broken -y
+sudo apt install /tmp/minecraft.deb -y
 rm /tmp/minecraft.deb
 ```
 

--- a/Applications/Games/Steam/Steam.md
+++ b/Applications/Games/Steam/Steam.md
@@ -24,8 +24,7 @@ sudo apt update
 sudo apt install libc6-i386 libutempter0 xbitmaps xterm libgl1-mesa-dri:i386 libgl1:i386 -y
 
 wget https://cdn.akamai.steamstatic.com/client/installer/steam.deb -O steam.deb
-sudo dpkg -i steam.deb
-sudo apt install --fix-broken -y
+sudo apt install ./steam.deb -y
 rm steam.deb
 ```
 

--- a/Applications/Internet-Services/Dropbox/Dropbox.md
+++ b/Applications/Internet-Services/Dropbox/Dropbox.md
@@ -7,8 +7,7 @@ To install Dropbox on AnduinOS, you can run:
 ```bash
 url=https://linux.dropbox.com/packages/ubuntu/dropbox_2024.04.17_amd64.deb
 wget $url -O dropbox.deb
-sudo dpkg -i dropbox.deb
-sudo apt install --fix-broken -y
+sudo apt install ./dropbox.deb -y
 rm dropbox.deb
 ```
 

--- a/Applications/Introduction.md
+++ b/Applications/Introduction.md
@@ -92,8 +92,7 @@ wget https://updates.insomnia.rest/downloads/ubuntu/latest -O insomnia.deb
 Then, you can install the .deb package by running:
 
 ```bash
-sudo dpkg -i insomnia.deb
-sudo apt install --fix-broken -y
+sudo apt install ./insomnia.deb -y
 ```
 
 !!! warning "Unable to automatically upgrade this application"

--- a/Applications/Media-Players/Yes-Play-Music/Yes-Play-Music.md
+++ b/Applications/Media-Players/Yes-Play-Music/Yes-Play-Music.md
@@ -2,14 +2,13 @@
 
 Yes-Play-Music is a beautiful third-party Netease Cloud Music client maintained by the community.
 
-To Install Yes-Play-Music on AnduinOS, first download a deb package from [here](https://github.com/qier222/YesPlayMusic/releases). Then you can install it with `dpkg`:
+To Install Yes-Play-Music on AnduinOS, first download a deb package from [here](https://github.com/qier222/YesPlayMusic/releases). Then you can install it with `apt`:
 
 <!-- The link needs to be updated regularly. -->
 
 ```bash
 wget https://github.com/qier222/YesPlayMusic/releases/download/v0.4.8-2/yesplaymusic_0.4.8_amd64.deb -O yesplaymusic.deb
-sudo dpkg -i yesplaymusic.deb
-sudo apt install --fix-broken -y
+sudo apt install ./yesplaymusic.deb -y
 rm yesplaymusic.deb
 ```
 

--- a/Applications/Office/WPS-Office/WPS-Office.md
+++ b/Applications/Office/WPS-Office/WPS-Office.md
@@ -8,8 +8,7 @@ To install WPS Office on AnduinOS, you can run:
 
 ```bash
 wget https://wdl1.pcfg.cache.wpscdn.com/wpsdl/wpsoffice/download/linux/11723/wps-office_11.1.0.11723.XA_amd64.deb -O wps.deb
-sudo dpkg -i wps.deb
-sudo apt install --fix-broken -y
+sudo apt install ./wps.deb -y
 rm wps.deb
 ```
 

--- a/Applications/Utilities/Terminus/Terminus.md
+++ b/Applications/Utilities/Terminus/Terminus.md
@@ -5,7 +5,6 @@ Terminus is a cross-platform terminal emulator that is available for Windows, ma
 ```bash
 link=https://www.termius.com/download/linux/Termius.deb
 wget $link -O terminus.deb
-sudo dpkg -i terminus.deb
-sudo apt install --fix-broken -y
+sudo apt install ./terminus.deb -y
 rm terminus.deb
 ```

--- a/Applications/Web-Browsers/Microsoft-Edge/Microsoft-Edge.md
+++ b/Applications/Web-Browsers/Microsoft-Edge/Microsoft-Edge.md
@@ -6,8 +6,7 @@ To install Microsoft Edge on AnduinOS, you can run:
 
 ```bash title="Install Microsoft Edge"
 wget https://go.microsoft.com/fwlink?linkid=2149051 -O microsoft-edge-stable.deb
-sudo dpkg -i microsoft-edge-stable.deb
-sudo apt install --fix-broken -y
+sudo apt install ./microsoft-edge-stable.deb -y
 rm microsoft-edge-stable.deb
 ```
 


### PR DESCRIPTION
Users should be encouraged to use `apt` instead of the more low-level `dpkg`.